### PR TITLE
Allow overwriting existing files and also selectively deleting files

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@
 S3method(print,compare_calibisg)
 export(available_data)
 export(bisg)
-export(delete_all_data)
+export(delete_data)
 export(download_data)
 export(load_data)
 export(most_probable_race)

--- a/R/predict.R
+++ b/R/predict.R
@@ -25,21 +25,21 @@
 #'
 #' @examples
 #' \dontrun{
-#' download_data(c("VT", "WA"), 2020)
+#' download_data(c("VT", "OK"), 2020)
 #'
-#' most_probable_race("Smith", "WA", "King")
+#' most_probable_race("Smith", "OK", "Tulsa")
 #' most_probable_race(
 #'   name = c("Lopez", "Jackson"),
-#'   state = c("VT", "WA"),
-#'   county = c("Chittenden", "King")
+#'   state = c("VT", "OK"),
+#'   county = c("Chittenden", "Tulsa")
 #' )
 #'
-#' race_probabilities("Smith", "WA", "King")
+#' race_probabilities("Smith", "OK", "Tulsa")
 #' race_probabilities("Lopez", "VT", "Chittenden")
 #' probs2 <- race_probabilities(
 #'   name = c("Lopez", "Smith"),
-#'   state = c("VT", "WA"),
-#'   county = c("Chittenden", "King")
+#'   state = c("VT", "OK"),
+#'   county = c("Chittenden", "Tulsa")
 #' )
 #' str(probs2)
 #' print(probs2, digits = 3)

--- a/man/caliBISG-data.Rd
+++ b/man/caliBISG-data.Rd
@@ -4,31 +4,35 @@
 \alias{caliBISG-data}
 \alias{calibisg-data}
 \alias{download_data}
-\alias{load_data}
+\alias{delete_data}
 \alias{available_data}
-\alias{delete_all_data}
+\alias{load_data}
 \title{Download caliBISG data files}
 \usage{
-download_data(state, year, progress = TRUE)
+download_data(state, year, progress = TRUE, overwrite = FALSE)
 
-load_data(state, year = 2020)
+delete_data(state, year)
 
 available_data()
 
-delete_all_data()
+load_data(state, year = 2020)
 }
 \arguments{
-\item{state}{(character vector) For \code{download_data()}, the states to
-download. The default is to download caliBISG data for all available
-states. If specifying particular states, they should be provided as
-two-letter abbreviations. For \code{load_data()}, a single state to load.}
+\item{state}{(character vector) For \code{download_data()} or \code{delete_data()}, the
+states to download or delete. The default is all available states. If
+specifying particular states, they should be provided as two-letter
+abbreviations. For \code{load_data()}, a single state to load.}
 
-\item{year}{(integer vector) For \code{download_data()}, the years to download.
-The default is to download caliBISG data for all available years. For
+\item{year}{(integer vector) For \code{download_data()} or \code{delete_data()}, the
+years to download or delete. The default is all available years. For
 \code{load_data()}, a single year to load.}
 
 \item{progress}{(logical) Whether to show a progress bar while downloading
 the data. The default is \code{TRUE}.}
+
+\item{overwrite}{(logical) For \code{download_data()}, whether to overwrite
+existing files if files with the same names already exist. The default is
+\code{FALSE}.}
 }
 \value{
 \itemize{
@@ -36,7 +40,8 @@ the data. The default is \code{TRUE}.}
 }
 
 \itemize{
-\item \code{load_data()}: (data frame) The caliBISG data for the specified state and year.
+\item \code{delete_data()}: (logical) Invisibly, a vector indicating if each specified
+file has been deleted successfully.
 }
 
 \itemize{
@@ -45,8 +50,7 @@ that have already been downloaded.
 }
 
 \itemize{
-\item \code{delete_all_data()}: (logical) \code{TRUE} or \code{FALSE}, invisibly,
-indicating success or failure.
+\item \code{load_data()}: (data frame) The caliBISG data for the specified state and year.
 }
 }
 \description{
@@ -83,10 +87,7 @@ times within one hour.
 }
 
 \itemize{
-\item \code{load_data()}: Load the data for a particular state and  year. This is only
-necessary if you want to work with the full data files directly. When using
-the functions provided by this package (e.g. \code{\link[=race_probabilities]{race_probabilities()}}) the data
-will be loaded internally automatically.
+\item \code{delete_data()}: Delete all or a subset of the data files stored internally.
 }
 
 \itemize{
@@ -95,18 +96,27 @@ downloaded and are available for use.
 }
 
 \itemize{
-\item \code{delete_all_data()}: Delete all the data files stored internally.
+\item \code{load_data()}: Load the data for a particular state and  year. This is only
+necessary if you want to work with the full data files directly. When using
+the functions provided by this package (e.g. \code{\link[=race_probabilities]{race_probabilities()}}) the data
+will be loaded internally automatically.
 }
 }
 \examples{
 \dontrun{
-# Download data just for Oklahoma and Washington for 2020
-download_data(state = c("OK", "WA"), year = 2020)
+# Download data just for Oklahoma and Vermont for 2020
+download_data(state = c("OK", "VT"), year = 2020)
 
 # Download all available data
 download_data()
 
 # List the data files that have already been downloaded
 available_data()
+
+# Delete the downloaded data for OK
+delete_data("OK")
+
+# Delete all downloaded data
+delete_data()
 }
 }

--- a/man/caliBISG-predict.Rd
+++ b/man/caliBISG-predict.Rd
@@ -141,21 +141,21 @@ table for each row in the returned data frame up to \code{max_print} rows.
 }
 \examples{
 \dontrun{
-download_data(c("VT", "WA"), 2020)
+download_data(c("VT", "OK"), 2020)
 
-most_probable_race("Smith", "WA", "King")
+most_probable_race("Smith", "OK", "Tulsa")
 most_probable_race(
   name = c("Lopez", "Jackson"),
-  state = c("VT", "WA"),
-  county = c("Chittenden", "King")
+  state = c("VT", "OK"),
+  county = c("Chittenden", "Tulsa")
 )
 
-race_probabilities("Smith", "WA", "King")
+race_probabilities("Smith", "OK", "Tulsa")
 race_probabilities("Lopez", "VT", "Chittenden")
 probs2 <- race_probabilities(
   name = c("Lopez", "Smith"),
-  state = c("VT", "WA"),
-  county = c("Chittenden", "King")
+  state = c("VT", "OK"),
+  county = c("Chittenden", "Tulsa")
 )
 str(probs2)
 print(probs2, digits = 3)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,2 +1,2 @@
 # start with a clean slate
-suppressMessages(delete_all_data())
+suppressMessages(delete_data())

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -49,8 +49,52 @@ test_that("download_data() throws expected messages and errors", {
   )
 })
 
-test_that("downloaded data recognized by available_data()", {
+test_that("download_data() can overwrite existing files", {
+  expect_message(
+    download_data("VT"),
+    "VT-2020.rds already exists. Skipping."
+  )
+
+  expect_message(
+    expect_message(
+      expect_message({
+        res <- download_data("VT", 2020, progress = FALSE, overwrite = TRUE)
+        expect_true(res)
+      },
+      regexp = "Downloading, reading, and saving file for: VT, 2020"),
+      regexp = "Downloading calibisg_vt2020.csv"
+    ),
+    regexp = "VT-2020.rds"
+  )
+})
+
+test_that("available_data() recognizes downloaded data", {
   expect_equal(available_data(), c("VT-2020.rds", "WA-2020.rds"))
+})
+
+test_that("delete_data() deletes downloaded data", {
+  suppressMessages(download_data("OK", progress = FALSE))
+  expect_equal(available_data(), c("OK-2020.rds", "VT-2020.rds", "WA-2020.rds"))
+  expect_message(
+    expect_true(delete_data("OK")),
+    "Deleting data file(s): OK-2020.rds",
+    fixed = TRUE
+  )
+  expect_equal(available_data(), c("VT-2020.rds", "WA-2020.rds"))
+
+  expect_message(
+    expect_equal(delete_data("OK"), logical()),
+    "No files found for deletion"
+  )
+
+  suppressMessages(download_data("OK", progress = FALSE))
+  expect_message(
+    expect_true(all(delete_data(c("OK", "VT")))),
+    "Deleting data file(s): OK-2020.rds, VT-2020.rds",
+    fixed = TRUE
+  )
+  expect_equal(available_data(), "WA-2020.rds")
+  suppressMessages(download_data("VT", progress = FALSE))
 })
 
 test_that("load_data() works as expected", {

--- a/vignettes/caliBISG.Rmd
+++ b/vignettes/caliBISG.Rmd
@@ -51,8 +51,8 @@ library(caliBISG)
 ## Download caliBISG data
 
 
-```{r setup-delete_all_data, echo=FALSE, message=FALSE}
-delete_all_data()
+```{r setup-delete_data, echo=FALSE, message=FALSE}
+delete_data()
 ```
 
 The `download_data()` function downloads the caliBISG data files from GitHub for
@@ -91,11 +91,13 @@ WA, we should see `OK-2020.rds` and `WA-2020.rds`.
 available_data()
 ```
 
-The `delete_all_data()` function deletes all files that have been downloaded.
+The `delete_data()` function deletes downloaded data files. Individual files can
+be specified via the `state` and `year` arguments. If no arguments are specified
+all files are deleted.
 
-```{r delete_all_data, eval = FALSE}
-# not actually evaluated to avoid deleting the data we just downloaded
-delete_all_data()
+```{r delete_data, eval = FALSE}
+# not evaluated to avoid deleting the data we just downloaded
+delete_data()
 ```
 
 


### PR DESCRIPTION
closes #29

* Introduces `overwrite` argument to `download_data()`
* Removes `delete_all_data()` in favor of `delete_data(state, year)`