### PR TITLE
warn if caliBISG files not downloaded

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -62,7 +62,8 @@ NULL
 #'   abbreviations. For `load_data()`, a single state to load.
 #' @param year (integer vector) For `download_data()` or `delete_data()`, the
 #'   years to download or delete. The default is all available years. For
-#'   `load_data()`, a single year to load.
+#'   `load_data()`, a single year to load. For `available_data()`, an optional
+#'   single year to filter the available data files.
 #' @param progress (logical) Whether to show a progress bar while downloading
 #'   the data. The default is `TRUE`.
 #' @param overwrite (logical) For `download_data()`, whether to overwrite
@@ -131,8 +132,12 @@ delete_data <- function(state, year) {
 #' @return * `available_data()`: (character vector) The names of the data files
 #'   that have already been downloaded.
 #'
-available_data <- function() {
-  list.files(.data_dir(), full.names = FALSE)
+available_data <- function(year) {
+  files <- list.files(.data_dir(), full.names = FALSE)
+  if (!missing(year)) {
+    files <- files[grepl(paste0("-", year, ".rds$"), files)]
+  }
+  files
 }
 
 #' @rdname caliBISG-data

--- a/R/predict.R
+++ b/R/predict.R
@@ -152,6 +152,7 @@ race_probabilities <- function(name, state, county, year = 2020) {
   name <- tolower(name)
   state <- .recycle(toupper(state), size = length(name))
   county <- .recycle(tolower(county), size = length(name))
+  .warn_if_not_downloaded(state, year)
 
   calibisg_list <- lapply(seq_along(name), function(i) {
     .get_single_calibisg_record(name[i], state[i], county[i], year)
@@ -388,6 +389,27 @@ fips_to_county <- function(fips, year = 2020) {
     stop("`name` must be a character vector.", call. = FALSE)
   }
   invisible(TRUE)
+}
+
+#' Warn if the caliBISG data for the given states and year haven't been downloaded
+#'
+#' @noRd
+#' @param state (character vector) A vector of state abbreviations.
+#' @param year (integer) The year of the data to check.
+#'
+.warn_if_not_downloaded <- function(state, year) {
+  states <- unique(state)
+  calibisg_states <- state[state %in% .all_calibisg_states()]
+  downloaded_states <- substr(available_data(year), 1, 2)
+  not_downloaded_states <- calibisg_states[!calibisg_states %in% downloaded_states]
+  if (length(not_downloaded_states)) {
+    warning(
+      "The caliBISG files for these states have not been downloaded: ",
+      paste(not_downloaded_states, collapse = ", "),
+      ". Please run `download_data()` first.",
+      call. = FALSE
+    )
+  }
 }
 
 #' Access internal data for converting fips to county

--- a/man/caliBISG-data.Rd
+++ b/man/caliBISG-data.Rd
@@ -13,7 +13,7 @@ download_data(state, year, progress = TRUE, overwrite = FALSE)
 
 delete_data(state, year)
 
-available_data()
+available_data(year)
 
 load_data(state, year = 2020)
 }
@@ -25,7 +25,9 @@ abbreviations. For \code{load_data()}, a single state to load.}
 
 \item{year}{(integer vector) For \code{download_data()} or \code{delete_data()}, the
 years to download or delete. The default is all available years. For
-\code{load_data()}, a single year to load.}
+\code{load_data()}, a single year to load. For \code{available_data()}, a single year
+to filter the available data files. If not specified, all years are
+considered.}
 
 \item{progress}{(logical) Whether to show a progress bar while downloading
 the data. The default is \code{TRUE}.}

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -1,10 +1,17 @@
 test_that("race_probabilities() warns if caliBISG files not downloaded", {
+  delete_data(c("FL", "NC"), 2020)
+
+  # FL and NC not downloaded, VA is not available
   expect_warning(
     expect_warning(
-      race_probabilities(c("Chan", "Chan"), c("FL", "NC"), c("miami-dade", "burke")),
+      race_probabilities(
+        name = c("Chan", "Chan", "Chan"),
+        state = c("FL", "VA", "NC"),
+        county = c("miami-dade", "fairfax", "burke")
+      ),
       "The caliBISG files for these states have not been downloaded: FL, NC"
     ),
-    "caliBISG is not available for 2 input(s). Returning NA estimates for those cases.",
+    "caliBISG is not available for 3 input(s). Returning NA estimates for those cases.",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -1,3 +1,15 @@
+test_that("race_probabilities() warns if caliBISG files not downloaded", {
+  expect_warning(
+    expect_warning(
+      race_probabilities(c("Chan", "Chan"), c("FL", "NC"), c("miami-dade", "burke")),
+      "The caliBISG files for these states have not been downloaded: FL, NC"
+    ),
+    "caliBISG is not available for 2 input(s). Returning NA estimates for those cases.",
+    fixed = TRUE
+  )
+})
+
+# download the rest of the states
 suppressMessages(download_data(year = 2020, progress = FALSE))
 
 test_that("race_probabilities() output hasn't changed", {


### PR DESCRIPTION
closes #37

If a user requests caliBISG for states we have but they haven't downloaded the file they will now see a warning like this: 

```
The caliBISG files for these states have not been downloaded: FL, NC. Please run `download_data()` first. 
```