### PR TITLE
speed improvements to most_probable_race for large data

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -104,18 +104,11 @@ most_probable_race <- function(name, state, county, year = 2020) {
   calibisg_labels <- sub("^calibisg_", "", calibisg_cols)
   bisg_labels <- sub("^bisg_", "", bisg_cols)
 
-  calibisg_matrix <- prediction[, calibisg_cols, drop = FALSE]
-  bisg_matrix <- prediction[, bisg_cols, drop = FALSE]
-  complete_calibisg <- stats::complete.cases(calibisg_matrix)
-  complete_bisg <- stats::complete.cases(bisg_matrix)
-
-  calibisg_idx <- rep(NA_integer_, nrow(calibisg_matrix))
-  bisg_idx <- rep(NA_integer_, nrow(bisg_matrix))
-  calibisg_idx[complete_calibisg] <- max.col(calibisg_matrix[complete_calibisg, , drop = FALSE])
-  bisg_idx[complete_bisg] <- max.col(bisg_matrix[complete_bisg, , drop = FALSE])
-
+  calibisg_idx <- max.col(prediction[, calibisg_cols, drop = FALSE])
+  bisg_idx <- max.col(prediction[, bisg_cols, drop = FALSE])
   prediction$calibisg_race <- calibisg_labels[calibisg_idx]
   prediction$bisg_race <- bisg_labels[bisg_idx]
+
   col_order <- c(
     .demographic_columns(),
     "calibisg_race",

--- a/R/predict.R
+++ b/R/predict.R
@@ -96,19 +96,26 @@ NULL
 #'         names that appear at least 100 times in the census.
 #'
 most_probable_race <- function(name, state, county, year = 2020) {
-  prediction <- as.data.frame(race_probabilities(name, state, county, year))
-  prediction$calibisg_race <- apply(
-    prediction[, .calibisg_columns()], 1, function(probs) {
-      if (anyNA(probs)) return(NA)
-      sub("^calibisg_", "", names(probs)[which.max(probs)])
-    }
-  )
-  prediction$bisg_race <- apply(
-    prediction[, .bisg_columns()], 1, function(probs) {
-      if (anyNA(probs)) return(NA)
-      sub("^bisg_", "", names(probs)[which.max(probs)])
-    }
-  )
+  prediction <- race_probabilities(name, state, county, year)
+  class(prediction) <- "data.frame"
+
+  calibisg_cols <- .calibisg_columns()
+  bisg_cols <- .bisg_columns()
+  calibisg_labels <- sub("^calibisg_", "", calibisg_cols)
+  bisg_labels <- sub("^bisg_", "", bisg_cols)
+
+  calibisg_matrix <- prediction[, calibisg_cols, drop = FALSE]
+  bisg_matrix <- prediction[, bisg_cols, drop = FALSE]
+  complete_calibisg <- stats::complete.cases(calibisg_matrix)
+  complete_bisg <- stats::complete.cases(bisg_matrix)
+
+  calibisg_idx <- rep(NA_integer_, nrow(calibisg_matrix))
+  bisg_idx <- rep(NA_integer_, nrow(bisg_matrix))
+  calibisg_idx[complete_calibisg] <- max.col(calibisg_matrix[complete_calibisg, , drop = FALSE])
+  bisg_idx[complete_bisg] <- max.col(bisg_matrix[complete_bisg, , drop = FALSE])
+
+  prediction$calibisg_race <- calibisg_labels[calibisg_idx]
+  prediction$bisg_race <- bisg_labels[bisg_idx]
   col_order <- c(
     .demographic_columns(),
     "calibisg_race",
@@ -117,6 +124,7 @@ most_probable_race <- function(name, state, county, year = 2020) {
   )
   prediction[, col_order]
 }
+
 
 #' @rdname caliBISG-predict
 #' @export

--- a/tests/testthat/_snaps/predict.md
+++ b/tests/testthat/_snaps/predict.md
@@ -269,11 +269,12 @@
 
 # most_probable_race() output hasn't changed
 
-    structure(list(name = c("lopez", "jackson", "smith", "chan"), 
-        year = c(2020, 2020, 2020, 2020), state = c("VT", "OK", "WA", 
-        "NC"), county = c("chittenden", "tulsa", "king", "wake"), 
-        calibisg_race = c("hispanic", "white_nh", "white_nh", "api"
-        ), bisg_race = c("hispanic", "black_nh", "white_nh", "api"
-        ), in_census = c(TRUE, TRUE, TRUE, TRUE)), class = "data.frame", row.names = c(NA, 
-    4L))
+    structure(list(name = c("lopez", "jackson", "smith", "chan", 
+    "noname", "thomas"), year = c(2020, 2020, 2020, 2020, 2020, 2020
+    ), state = c("VT", "OK", "WA", "NC", "WA", "OK"), county = c("chittenden", 
+    "tulsa", "king", "wake", "king", "tulsa"), calibisg_race = c("hispanic", 
+    "white_nh", "white_nh", "api", NA, "white_nh"), bisg_race = c("hispanic", 
+    "black_nh", "white_nh", "api", "white_nh", "white_nh"), in_census = c(TRUE, 
+    TRUE, TRUE, TRUE, NA, TRUE)), class = "data.frame", row.names = c(NA, 
+    6L))
 

--- a/tests/testthat/_snaps/predict.md
+++ b/tests/testthat/_snaps/predict.md
@@ -272,9 +272,9 @@
     structure(list(name = c("lopez", "jackson", "smith", "chan", 
     "noname", "thomas"), year = c(2020, 2020, 2020, 2020, 2020, 2020
     ), state = c("VT", "OK", "WA", "NC", "WA", "OK"), county = c("chittenden", 
-    "tulsa", "king", "wake", "king", "tulsa"), calibisg_race = c("hispanic", 
-    "white_nh", "white_nh", "api", NA, "white_nh"), bisg_race = c("hispanic", 
-    "black_nh", "white_nh", "api", "white_nh", "white_nh"), in_census = c(TRUE, 
-    TRUE, TRUE, TRUE, NA, TRUE)), class = "data.frame", row.names = c(NA, 
+    "tulsa", "king", "wake", "king", "noname"), calibisg_race = c("hispanic", 
+    "white_nh", "white_nh", "api", NA, NA), bisg_race = c("hispanic", 
+    "black_nh", "white_nh", "api", "white_nh", NA), in_census = c(TRUE, 
+    TRUE, TRUE, TRUE, NA, NA)), class = "data.frame", row.names = c(NA, 
     6L))
 

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -303,7 +303,7 @@ test_that("most_probable_race() output hasn't changed", {
     suppressWarnings(most_probable_race(
       name   = c("lopez", "jackson", "smith", "chan", "noname", "thomas"),
       state  = c("VT", "OK", "WA", "NC", "WA", "OK"),
-      county = c("Chittenden", "Tulsa", "King", "Wake", "King", "Tulsa"),
+      county = c("Chittenden", "Tulsa", "King", "Wake", "King", "noname"),
       year   = 2020
     )),
     style = "deparse"

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -300,12 +300,12 @@ test_that("print.compare_calibisg() handles edge cases", {
 
 test_that("most_probable_race() output hasn't changed", {
   expect_snapshot_value(
-    most_probable_race(
-      name   = c("lopez", "jackson", "smith", "chan"),
-      state  = c("VT", "OK", "WA", "NC"),
-      county = c("Chittenden", "Tulsa", "King", "Wake"),
+    suppressWarnings(most_probable_race(
+      name   = c("lopez", "jackson", "smith", "chan", "noname", "thomas"),
+      state  = c("VT", "OK", "WA", "NC", "WA", "OK"),
+      county = c("Chittenden", "Tulsa", "King", "Wake", "King", "Tulsa"),
       year   = 2020
-    ),
+    )),
     style = "deparse"
   )
 })


### PR DESCRIPTION
closes #48

* Replaced rowwise apply calls in most_probable_race with a vectorized max.col approach 
* precomputed labels to avoid calling `sub` repeatedly

